### PR TITLE
Switch CDN in use from RawGit to GitCDN.xyz in BetterDiscord theme stub.

### DIFF
--- a/BetterDiscord/Readme.md
+++ b/BetterDiscord/Readme.md
@@ -1,6 +1,6 @@
 
 # Crystalline-css Better Discord
-This is a stub file meant to allow the Crystalline css theme file to work with Better Discord.  For convenience it imports the css file from GitHub directly so it is always kept up to date.  A couple of typical configuration options are given to allow changing the background as well as it's size. ~[shinji257](https://github.com/shinji257)<br>
+This is a stub file meant to allow the Crystalline css theme file to work with Better Discord.  For convenience it imports the css file from GitHub via GitCDN.xyz so it is almost always kept up to date.  A couple of typical configuration options are given to allow changing the background as well as it's size. ~[shinji257](https://github.com/shinji257)<br>
 
 ## Requirements
 To apply this CSS to Discord, you should have [BetterDiscord](https://betterdiscord.net/home/) installed!<br>

--- a/BetterDiscord/crystalline.theme.css
+++ b/BetterDiscord/crystalline.theme.css
@@ -1,6 +1,6 @@
 //META{"name":"Crystalline","description":"Crystalline is a BeautifulDiscord theme focused on using non-rounded edges, dark colors, and transparent windows.","author":"SamuiNe","version":"latest"}*//
 
-@import 'https://cdn.rawgit.com/SamuiNe/Crystalline-css/master/crystalline.css';
+@import 'https://gitcdn.xyz/repo/SamuiNe/Crystalline-css/master/crystalline.css';
 
 /* By default these are commented out.  You can uncomment the settings below and change them to something that you may prefer otherwise the default in the original css will be used instead. */
 


### PR DESCRIPTION
Unfortunately, RawGit doesn't actually update in real time (my bad) and the link is a permanent cache.  It doesn't ever update.  I switched to GitCDN.xyz which will update cache as needed if it detects changes on the pushed copy.  The delay in updates is supposed to be 2 hours max.