### PR TITLE
Fixed margins, dividers for new message notif

### DIFF
--- a/crystalline.css
+++ b/crystalline.css
@@ -1,6 +1,6 @@
 /**********************************************************
  *           Crystalline CSS for BeautifulDiscord         *
- *                     Version 1.18.0                     *
+ *                     Version 1.18.1                     *
  *                                                        *
  *                   Created by SamuiNe                   *
  *               https://github.com/SamuiNe               *
@@ -4462,15 +4462,9 @@ input{
     background-color: rgba(0, 0, 0, 0);
 }
 
-/* TODO: Fix Blocked Messages properly */
+
 .messageGroupBlocked-3wrQQX{
-    background-color: rgba(0, 0, 0, 0) !important;
-    border: none;
-    border-bottom: 1px solid hsla(0,0%,100%, 0.04) !important;
-    border-color: hsla(0,0%,100%, 0.04) !important;
-    box-shadow: none !important;
-    margin: 0 20px 0 20px;
-    height: 0;
+    border-bottom: 0px;
 }
 
 .theme-dark .messageGroupBlocked-3wrQQX .messageGroupBlockedBtn-1PBBh-{
@@ -4645,5 +4639,50 @@ input{
 .theme-dark .isLocalBot-38G0P0{
     background-image: none;
     background-color: rgba(255, 255, 255, 0.1);
+
+}
+
+/* Discord update 2018/10/5 and previous updates */
+
+/* ｓｌｏｗ　ｍｏｄｅ text color */
+
+.cooldownWrapper-3joyFc{
+    color: rgb(255, 190, 120) !important;
+}
+
+/* Fix 'New Messages' margin and width */
+.theme-dark .divider-3gKybi.dividerRed-MKoLlr>span{
+    margin-top: 1px;
+    margin-bottom: -20px;
+}
+
+.theme-dark .divider-3gKybi.dividerRed-MKoLlr{
+    width: 180px;
+}
+
+/* Fix border colors for 'hidden' dividers */
+
+.containerCozy-jafyvG .divider-32i8lo{
+    border-color: hsla(0,0%,100%,.04);
+}
+
+/* Fix margins for date dividers */
+
+.theme-dark .divider-3gKybi:not(.dividerRed-MKoLlr) .dividerContent-2L12VI{
+
+    color: rgba(255, 255, 255, 0.5);
+    margin-top: -10px;
+    margin-bottom: -9px;
+}
+
+.theme-dark .divider-3gKybi:not(.dividerRed-MKoLlr) .dividerContent-2L12VI:after, .theme-dark .divider-3gKybi:not(.dividerRed-MKoLlr) .dividerContent-2L12VI:before{
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Make blocked messages divider hidden */
+
+.divider-3zi9LO+.messageGroupBlocked-JqfeE2,
+.messageGroupBlocked-3wrQQX{
+    border: none;
 
 }


### PR DESCRIPTION
Version 1.18.0 > 1.18.1

Changed slow mode text color

Fixed 'New messages' width

Fixed border colors for 'hidden' dividers

Fixed border colors for 'hidden' dividers

Fixed margins for date dividers

Fixed blocked messages divider showing up twice

Other fixes coming soon again