### PR TITLE
private channel list fix

### DIFF
--- a/crystalline.css
+++ b/crystalline.css
@@ -1,6 +1,6 @@
 /**********************************************************
  *           Crystalline CSS for BeautifulDiscord         *
- *                     Version 1.22.1                     *
+ *                     Version 1.22.2                     *
  *                                                        *
  *                   Created by SamuiNe                   *
  *               https://github.com/SamuiNe               *
@@ -5847,4 +5847,10 @@ input{
 
 .app-2rEoOp{
     background-color: rgba(0, 0, 0, 0);
+}
+
+/* private channel list fix */
+
+.privateChannels-1nO12o{
+	background-color: rgba(0, 0, 0, 0);
 }


### PR DESCRIPTION
For me, v1.22.1 didn't fix the non transparent background for the private dm list. This fixes it