### PR TITLE
Text input background fixed (again)

### DIFF
--- a/crystalline.css
+++ b/crystalline.css
@@ -5875,10 +5875,6 @@ input{
 }
 
 /* Text input background fixed */
-.innerEnabled-3g80kR.inner-zqa7da {
-    background-color: transparent !important;
-}
-
-.scrollableContainer-38zsVD {
-    background-color: rgba(0, 0, 0, 0.5) !important;
+.scrollableContainer-2NUZem.webkit-HjD9Er {
+    background-color: rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
This reverts https://github.com/SamuiNe/Crystalline-css/pull/33 from me and fixes it for the new layout again. The old stuff is not needed anymore for it